### PR TITLE
Change network name in docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
     env_file:
       - ./.env.prod
     networks:
-      - nginx_nginx-proxynet
+      - reverseproxy_proxynet
 
   nginx:
     restart: always
@@ -35,12 +35,12 @@ services:
       - LETSENCRYPT_EMAIL=dybber@di.ku.dk
       - url=https://blockchain-sim.dataekspeditioner.dk.dk
     networks:
-      - nginx_nginx-proxynet
+      - reverseproxy_proxynet
 
 volumes:
   database_volume: {}
   static_volume: {}
 
 networks:
-  nginx_nginx-proxynet:
+  reverseproxy_proxynet:
     external: true


### PR DESCRIPTION
The internal network name between docker containers is changed on the server, and the docker-compose.prod.yml thus needs to be updated.